### PR TITLE
Changes PHP and WordPress requirements

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,10 @@
 Contributors: skyverge, beka.rice
 Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
-Requires at least: 4.7
-Tested up to: 6.0.1
-Stable Tag: 2.4.8
+Requires at least: 5.6
+Requires PHP: 7.4
+Tested up to: 6.1.1
+Stable Tag: 2.4.9-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -153,6 +154,9 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 `
 
 == Changelog ==
+
+= 2022.nn.nn - version 2.4.9-dev.1 =
+ * Misc - Require PHP 7.4 and WordPress 5.6
 
 = 2022.07.31 - version 2.4.8 =
  * Fix - Sanitize input

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -5,7 +5,7 @@
  * Description: Automatically generate SKUs for products using the product / variation slug and/or ID
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.4.8
+ * Version: 2.4.9-dev.1
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
@@ -45,7 +45,7 @@ class WC_SKU_Generator {
 
 
 	/** plugin version number */
-	const VERSION = '2.4.8';
+	const VERSION = '2.4.9-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.9.4';


### PR DESCRIPTION
# Story [MWC-8972](https://godaddy-corp.atlassian.net/browse/MWC-8972)
## Summary
In order to keep the codebase up to date to the latest WordPress release requirements, it was needed to update the plugin's requirements as well, and make sure everything runs fine.

### QA Steps

- [ ] Make sure you are using PHP 7.4 or above
- [ ] Make sure you are using the latest WordPress version
- [ ] Make sure you are using the latest WooCommerce version
- [ ] Install and activate the plugin
- [ ] Make sure to have some products in your testing store
- [ ] Access the plugins `Configure` option, and select set the SKU's generation up on `Product SKUs` section
- [ ] Update some products in order to validate auto generated SKU's
- [ ] Validate the effects in your products catalog shop page