### PR TITLE
HPOS support in Product SKU Generator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.jshintrc,*.json,*.toml,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.txt}]
+end_of_line = crlf

--- a/readme.txt
+++ b/readme.txt
@@ -158,6 +158,7 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 = 2023.nn.nn - version 2.5.0-dev.1 =
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)
  * Misc - Require PHP 7.4+ and WordPress 5.6+
+ * Dev - Add `wc_sku_generator_variation_attributes` filter to allow modification of variation attributes used for SKU generation
 
 = 2022.07.31 - version 2.4.8 =
  * Fix - Sanitize input

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,10 @@
 Contributors: skyverge, beka.rice
 Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
-Requires at least: 4.7
+Requires at least: 5.6
 Tested up to: 6.0.1
-Stable Tag: 2.4.8
+Requires PHP: 7.4
+Stable Tag: 2.5.0-dev.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -64,7 +65,7 @@ This action will also automatically generate the SKUs for product variations if 
 
 > **NOTE that** any time a product is updated, its SKU will be generated, so this may override old SKUs if you update products. This plugin is meant for complete SKU automation, or you can selectively enable / disable it as needed.
 
- 1. Be sure you're running WooCommerce 2.5+ in your shop.
+ 1. Be sure you're running WooCommerce 3.9+ in your shop.
 
  2. You can:
 
@@ -153,6 +154,10 @@ add_filter( 'wc_sku_generator_force_attribute_sorting', '__return_true' );
 `
 
 == Changelog ==
+
+= 2023.nn.nn - version 2.5.0-dev.1 =
+ * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)
+ * Misc - Require PHP 7.4+ and WordPress 5.6+
 
 = 2022.07.31 - version 2.4.8 =
  * Fix - Sanitize input

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -5,17 +5,17 @@
  * Description: Automatically generate SKUs for products using the product / variation slug and/or ID
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com/
- * Version: 2.4.8
+ * Version: 2.5.0-dev.1
  * Text Domain: woocommerce-product-sku-generator
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2014-2022, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2014-2023, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2014-2022, SkyVerge, Inc. (info@skyverge.com)
+ * @copyright Copyright (c) 2014-2023, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.9.4
@@ -45,7 +45,7 @@ class WC_SKU_Generator {
 
 
 	/** plugin version number */
-	const VERSION = '2.4.8';
+	const VERSION = '2.5.0-dev.1';
 
 	/** required WooCommerce version number */
 	const MIN_WOOCOMMERCE_VERSION = '3.9.4';
@@ -93,6 +93,26 @@ class WC_SKU_Generator {
 
 			// run every time
 			$this->install();
+		}
+
+		// handle HPOS compatibility
+		add_action( 'before_woocommerce_init', [ $this, 'handle_hpos_compatibility' ] );
+	}
+
+
+	/**
+	 * Declares HPOS compatibility.
+	 *
+	 * @since 2.5.0-dev.1
+	 *
+	 * @internal
+	 *
+	 * @return void
+	 */
+	public function handle_hpos_compatibility()
+	{
+		if ( class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', plugin_basename( __FILE__ ), true );
 		}
 	}
 
@@ -365,14 +385,14 @@ class WC_SKU_Generator {
 		// save the SKU for simple / external / parent products if we should
 		if ( 'never' !== get_option( 'wc_sku_generator_simple' ) ) {
 
-            $product_sku = wc_product_generate_unique_sku( $product->get_id(), $product_sku );
+			$product_sku = wc_product_generate_unique_sku( $product->get_id(), $product_sku );
 
-            try {
+			try {
 
-                $product->set_sku( $product_sku );
-                $product->save();
+				$product->set_sku( $product_sku );
+				$product->save();
 
-            } catch ( WC_Data_Exception $exception ) {}
+			} catch ( WC_Data_Exception $exception ) {}
 		}
 	}
 
@@ -407,14 +427,14 @@ class WC_SKU_Generator {
 			 */
 			$sku = apply_filters( 'wc_sku_generator_variation_sku_format', $sku, $parent_sku, $variation_sku );
 
-            try {
+			try {
 
-                $sku = wc_product_generate_unique_sku( $variation_id, $sku );
+				$sku = wc_product_generate_unique_sku( $variation_id, $sku );
 
-                $variation->set_sku( $sku );
-                $variation->save();
+				$variation->set_sku( $sku );
+				$variation->save();
 
-            } catch ( WC_Data_Exception $exception ) {}
+			} catch ( WC_Data_Exception $exception ) {}
 		}
 	}
 

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -320,9 +320,11 @@ class WC_SKU_Generator {
 			 * Attributes in SKUs _could_ be sorted inconsistently in rare cases.
 			 * Return true here to ensure they're always sorted consistently.
 			 *
-			 * @since 2.0.0
-			 * @param bool $sort_atts true to force attribute sorting
 			 * @see https://github.com/skyverge/woocommerce-product-sku-generator/pull/2
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param bool $sort_atts true to force attribute sorting
 			 */
 			if ( apply_filters( 'wc_sku_generator_force_attribute_sorting', false ) ) {
 				ksort( $variation['attributes'] );
@@ -332,11 +334,21 @@ class WC_SKU_Generator {
 			 * Filters the separator used between variation attributes.
 			 *
 			 * @since 2.0.0
+			 *
 			 * @param string $separator the separator character
 			 */
 			$separator = apply_filters( 'wc_sku_generator_attribute_separator', $this->get_sku_separator() );
 
-			$variation_sku = implode( $separator, $variation['attributes'] );
+			/**
+			 * Filters attributes that are used in generating the variation's SKU.
+			 *
+			 * @since 2.5.0-dev.1
+			 *
+			 * @param array $variation_attributes variation attributes before they are imploded for SKU generation
+			 */
+			$variation_attributes = apply_filters('wc_sku_generator_variation_attributes', $variation['attributes'] );
+
+			$variation_sku = implode( $separator, $variation_attributes );
 			$variation_sku = str_replace( 'attribute_', '', $variation_sku );
 		}
 
@@ -349,6 +361,7 @@ class WC_SKU_Generator {
 		 * Filters the generated variation portion of the SKU.
 		 *
 		 * @since 2.0.0
+		 *
 		 * @param string $variation_sku the generated variation portion of the SKU
 		 * @param array $variation product variation data
 		 */


### PR DESCRIPTION
## Summary

Adds support to HPOS in Product SKU Generator as per [discovery doc](https://docs.google.com/document/d/1752eyK4-9d-bxlOc2ZbAbZqEk91O5aPPrZHC-U0ovYE/edit#bookmark=id.g7vns4f25d91).

Also adds a filter originally proposed in #35 (however it doesn't filter the whole `$variation` arg, which is later passed again in `wc_sku_generator_variation_sku` and it's best we leave it unmodified).


### Story: [MWC-11023](https://godaddy-corp.atlassian.net/browse/MWC-11023)


