### PR TITLE
Bump tested-up-to values to WordPress 6.7 and WooCommerce 9.3.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: skyverge, beka.rice
 Tags: woocommerce, sku, product sku, sku generator
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@skyverge.com&item_name=Donation+for+WooCommerce+SKU+Generator
 Requires at least: 5.6
-Tested up to: 6.2.2
+Tested up to: 6.7
 Requires PHP: 7.4
 Stable Tag: 2.5.0
 License: GPLv3

--- a/woocommerce-product-sku-generator.php
+++ b/woocommerce-product-sku-generator.php
@@ -19,7 +19,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.9.4
- * WC tested up to: 7.9.0
+ * WC tested up to: 9.3.3
  */
 
 defined( 'ABSPATH' ) or exit;


### PR DESCRIPTION
Tested on:
- WordPress 6.7-RC1
- WooCommerce 9.3.3

Already bumped the tested-up-to values directly via svn, see https://plugins.trac.wordpress.org/changeset/3177613.